### PR TITLE
Consolidate SQLAlchemy models

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,20 +1,16 @@
 # database.py
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker, declarative_base
-from sqlalchemy import Column, BigInteger, Integer, String
+from sqlalchemy.orm import sessionmaker
+
+from models import Base, User
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 engine = create_async_engine(DATABASE_URL, echo=True)
-SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
-Base = declarative_base()
 
-class User(Base):
-    __tablename__ = "users"
-    id = Column(Integer, primary_key=True)
-    telegram_id = Column(BigInteger, unique=True, index=True)
-    phone = Column(String, unique=True)
+# sessionmaker for creating async database sessions
+async_session = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
 
 async def init_db():
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
- centralize the `User` model and `Base` in `models.py`
- refactor `database.py` to import these definitions
- expose `async_session` for creating DB sessions

## Testing
- `python -m py_compile bot.py database.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68422b18df9883208b8d2b9d34f9fc30