### PR TITLE
Add async_session factory

### DIFF
--- a/database.py
+++ b/database.py
@@ -7,7 +7,13 @@ import os
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 engine = create_async_engine(DATABASE_URL, echo=True)
-SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+# Session factory for creating asynchronous sessions
+async_session = sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
 Base = declarative_base()
 
 class User(Base):


### PR DESCRIPTION
## Summary
- switch DB session factory to async_session using `sessionmaker`
- provide async_session for use in `bot.py`

## Testing
- `python bot.py` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_68422b183ac08320877ed86fd7e30861